### PR TITLE
Small changes to be able to compile with rust 1.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lifx"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Ferris Tseng"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Ferris Tseng"]
 
 [dependencies]
 log = "*"
-bitflags = "*"
+bitflags = "1.0"
 byteorder = "*"
 rustc-serialize = "*"
 net2 = { version = "*", features = ["nightly"] }
 
 [dev-dependencies]
-env_logger = "*"
+env_logger = "0.5.10"

--- a/examples/lifx_get_service.rs
+++ b/examples/lifx_get_service.rs
@@ -4,15 +4,15 @@ extern crate env_logger;
 use std::thread;
 use std::time::Duration;
 
-use lifx::{GET_ALL, Client};
+use lifx::{DiscoverOptions, Client};
 
 
 fn main() {
-  env_logger::init().unwrap();
+  env_logger::init();
 
   let client = Client::new("0.0.0.0:1234").unwrap();
   let thread = client.listen();
-  let discover_thread = client.discover(1000, GET_ALL);
+  let discover_thread = client.discover(1000, DiscoverOptions::GET_ALL);
 
   println!("Waiting 10 seconds to discover devices...");
 

--- a/examples/lifx_power_on.rs
+++ b/examples/lifx_power_on.rs
@@ -11,7 +11,7 @@ static ADDR: &'static str = "10.0.1.4:56700";
 
 
 fn main() {
-  env_logger::init().unwrap();
+  env_logger::init();
 
   let client = Client::new("0.0.0.0:1234").unwrap();
   let _ = client.send_msg(ADDR,

--- a/examples/lifx_rainbow.rs
+++ b/examples/lifx_rainbow.rs
@@ -16,7 +16,7 @@ static ADDR: &'static str = "10.0.1.4:56700";
 
 
 fn main() {
-  env_logger::init().unwrap();
+  env_logger::init();
 
   let client = Client::new("0.0.0.0:1234").unwrap();
   let thread = client.listen();

--- a/src/client.rs
+++ b/src/client.rs
@@ -60,18 +60,19 @@ fn send_msg<S: Deref<Target = UdpSocket>, A: ToSocketAddrs>
 
 
 bitflags! {
-  pub flags DiscoverOptions: u8 {
-    const GET_LABEL         = 0b0000_0001,
-    const GET_WIFI          = 0b0000_0010,
-    const GET_LOCATION      = 0b0000_0100,
-    const GET_HOST_FIRMWARE = 0b0000_1000,
-    const GET_GROUP         = 0b0001_0000,
-    const GET_POWER         = 0b0010_0000,
-    const GET_HOST_INFO     = 0b0100_0000,
-    const GET_ALL           = GET_LABEL.bits | GET_WIFI.bits |
-                              GET_LOCATION.bits | GET_HOST_FIRMWARE.bits |
-                              GET_GROUP.bits | GET_POWER.bits |
-                              GET_HOST_INFO.bits
+  pub struct DiscoverOptions: u8 {
+    const GET_LABEL         = 0b0000_0001;
+    const GET_WIFI          = 0b0000_0010;
+    const GET_LOCATION      = 0b0000_0100;
+    const GET_HOST_FIRMWARE = 0b0000_1000;
+    const GET_GROUP         = 0b0001_0000;
+    const GET_POWER         = 0b0010_0000;
+    const GET_HOST_INFO     = 0b0100_0000;
+    const GET_ALL           = DiscoverOptions::GET_LABEL.bits |
+                              DiscoverOptions::GET_WIFI.bits |
+                              DiscoverOptions::GET_LOCATION.bits | DiscoverOptions::GET_HOST_FIRMWARE.bits |
+                              DiscoverOptions::GET_GROUP.bits | DiscoverOptions::GET_POWER.bits |
+                              DiscoverOptions::GET_HOST_INFO.bits;
   }
 }
 
@@ -279,32 +280,32 @@ impl Client {
         let _ = socket.set_broadcast(false);
 
         for d in devices.read().unwrap().values() {
-          if !(options & GET_LABEL).is_empty() {
+          if !(options & DiscoverOptions::GET_LABEL).is_empty() {
             let _ = d.send_msg_and_wait(Payload::Device(Device::GetLabel), false);
           }
 
-          if !(options & GET_POWER).is_empty() {
+          if !(options & DiscoverOptions::GET_POWER).is_empty() {
             let _ = d.send_msg_and_wait(Payload::Device(Device::GetPower), false);
           }
 
-          if !(options & GET_LOCATION).is_empty() {
+          if !(options & DiscoverOptions::GET_LOCATION).is_empty() {
             let _ = d.send_msg_and_wait(Payload::Device(Device::GetLocation), false);
           }
 
-          if !(options & GET_GROUP).is_empty() {
+          if !(options & DiscoverOptions::GET_GROUP).is_empty() {
             let _ = d.send_msg_and_wait(Payload::Device(Device::GetGroup), false);
           }
 
-          if !(options & GET_HOST_INFO).is_empty() {
+          if !(options & DiscoverOptions::GET_HOST_INFO).is_empty() {
             let _ = d.send_msg_and_wait(Payload::Device(Device::GetHostInfo), false);
           }
 
-          if !(options & GET_HOST_FIRMWARE).is_empty() {
+          if !(options & DiscoverOptions::GET_HOST_FIRMWARE).is_empty() {
             let _ = d.send_msg_and_wait(Payload::Device(Device::GetHostFirmware),
                                         false);
           }
 
-          if !(options & GET_WIFI).is_empty() {
+          if !(options & DiscoverOptions::GET_WIFI).is_empty() {
             let _ = d.send_msg_and_wait(Payload::Device(Device::GetWifiFirmware),
                                         false);
           }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,4 @@ pub use header::Header;
 pub use message::Message;
 pub use payload::{Service, Device, Light, Payload, Power, HSBK, Color,
                   MAX_BRIGHTNESS};
-pub use client::{Bulb, Client, DiscoverOptions, GET_ALL, GET_LABEL, GET_WIFI,
-                 GET_LOCATION, GET_HOST_FIRMWARE, GET_GROUP, GET_POWER,
-                 GET_HOST_INFO};
+pub use client::{Bulb, Client, DiscoverOptions};


### PR DESCRIPTION
- Updating dependencies to pinned versions to use bitflags = "1.0" and env_logger = "0.5.10"
- Few small changes to be able to compile under rust 1.26