### PR TITLE
Formatted source code with cargo fmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.bk
+rls

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lifx"
 version = "0.1.2"
 authors = ["Ferris Tseng"]
+license = "MIT"
 
 [dependencies]
 log = "*"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) <2015> <Ferris Tseng>
+Copyright (c) <2015, 2016, 2017, 2018> <Ferris Tseng>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ loggers:
 
 The MIT License (MIT)
 
-Copyright (c) <2015> <Ferris Tseng>
+Copyright (c) <2015, 2016, 2017, 2018> <Ferris Tseng>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/lifx_get_service.rs
+++ b/examples/lifx_get_service.rs
@@ -1,11 +1,10 @@
-extern crate lifx;
 extern crate env_logger;
+extern crate lifx;
 
 use std::thread;
 use std::time::Duration;
 
-use lifx::{DiscoverOptions, Client};
-
+use lifx::{Client, DiscoverOptions};
 
 fn main() {
   env_logger::init();

--- a/examples/lifx_power_on.rs
+++ b/examples/lifx_power_on.rs
@@ -1,23 +1,23 @@
-extern crate lifx;
 extern crate env_logger;
+extern crate lifx;
 
 use lifx::Light::*;
 use lifx::{Client, Payload, Power};
-
 
 const TARGET: u64 = 3732340569040;
 
 static ADDR: &'static str = "10.0.1.4:56700";
 
-
 fn main() {
   env_logger::init();
 
   let client = Client::new("0.0.0.0:1234").unwrap();
-  let _ = client.send_msg(ADDR,
-                          Payload::Light(SetPower(Power::Max, 500)),
-                          true,
-                          TARGET);
+  let _ = client.send_msg(
+    ADDR,
+    Payload::Light(SetPower(Power::Max, 500)),
+    true,
+    TARGET,
+  );
 
   client.close();
 }

--- a/examples/lifx_rainbow.rs
+++ b/examples/lifx_rainbow.rs
@@ -1,5 +1,5 @@
-extern crate lifx;
 extern crate env_logger;
+extern crate lifx;
 #[macro_use]
 extern crate log;
 
@@ -7,21 +7,18 @@ use std::thread;
 use std::time::Duration;
 
 use lifx::Light::*;
-use lifx::{Client, Color, HSBK, Payload, MAX_BRIGHTNESS};
+use lifx::{Client, Color, Payload, HSBK, MAX_BRIGHTNESS};
 
 const DELAY: u32 = 500;
 const TARGET: u64 = 3732340569040;
 
 static ADDR: &'static str = "10.0.1.4:56700";
 
-
 fn main() {
   env_logger::init();
 
   let client = Client::new("0.0.0.0:1234").unwrap();
   let thread = client.listen();
-
-
 
   println!("Setting to green...");
 
@@ -30,14 +27,11 @@ fn main() {
   //                        true,
   //                        TARGET);
 
-
   println!("Setting to white...");
 
   let white = HSBK::new(0, 3000, !0, 2500);
-  let _ = client.send_msg(ADDR,
-                          Payload::Light(SetColor(white, DELAY)),
-                          false,
-                          TARGET);
+  let _ =
+    client.send_msg(ADDR, Payload::Light(SetColor(white, DELAY)), false, TARGET);
 
   thread::sleep(Duration::from_secs(5));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(unicode)]
 
-extern crate net2;
 extern crate byteorder;
+extern crate net2;
 extern crate rustc_serialize;
 #[macro_use]
 extern crate log;
@@ -14,12 +14,13 @@ macro_rules! err(
 
 mod client;
 mod header;
-mod payload;
 mod message;
+mod payload;
 pub mod serialize;
 
+pub use client::{Bulb, Client, DiscoverOptions};
 pub use header::Header;
 pub use message::Message;
-pub use payload::{Service, Device, Light, Payload, Power, HSBK, Color,
-                  MAX_BRIGHTNESS};
-pub use client::{Bulb, Client, DiscoverOptions};
+pub use payload::{
+  Color, Device, Light, Payload, Power, Service, HSBK, MAX_BRIGHTNESS,
+};

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,12 +1,10 @@
-use std::fmt::{Formatter, Debug, Error};
+use std::fmt::{Debug, Error, Formatter};
 
 use header::Header;
 use payload::Payload;
-use rustc_serialize::{Encoder, Encodable, Decoder, Decodable};
-
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 const CLIENT_ID: u32 = 1111;
-
 
 pub struct Message {
   header: Header,
@@ -18,14 +16,16 @@ impl Message {
   ///
   pub fn new(msg: Payload, ack_required: bool, target: u64, seq: u8) -> Message {
     Message {
-      header: Header::new(msg.size() + Header::mem_size(),
-                          msg.tagged(),
-                          CLIENT_ID,
-                          target,
-                          ack_required,
-                          msg.requires_response(),
-                          seq,
-                          msg.typ()),
+      header: Header::new(
+        msg.size() + Header::mem_size(),
+        msg.tagged(),
+        CLIENT_ID,
+        target,
+        ack_required,
+        msg.requires_response(),
+        seq,
+        msg.typ(),
+      ),
       payload: msg,
     }
   }
@@ -58,9 +58,11 @@ impl Decodable for Message {
   fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
     d.read_struct("Header", 0, |mut d| {
       let header = try!(d.read_struct_field("header", 0, |mut d| Header::decode(d)));
-      let message = try!(d.read_struct_field("payload", 0, |mut d| {
-        Payload::decode(d, header.typ())
-      }));
+      let message = try!(d.read_struct_field(
+        "payload",
+        0,
+        |mut d| Payload::decode(d, header.typ())
+      ));
 
       Ok(Message {
         header: header,

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,17 +1,14 @@
 use std::convert::Into;
-use std::fmt::{Debug, Formatter, Error};
+use std::fmt::{Debug, Error, Formatter};
 
-use rustc_serialize::{Encodable, Encoder, Decodable, Decoder};
-
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 /// Max allowable brightness.
 ///
 pub const MAX_BRIGHTNESS: u16 = ::std::u16::MAX;
 
-
 const MAX_SATURATION: u16 = ::std::u16::MAX;
 const DEFAULT_KELVIN: u16 = 3500;
-
 
 /// Preseeded HSBK values for convenience.
 ///
@@ -33,58 +30,45 @@ impl Color {
     use Color::*;
 
     match self {
-      Red => {
-        HSBK {
-          hue: 0,
-          saturation: MAX_SATURATION,
-          brightness: brightness,
-          kelvin: DEFAULT_KELVIN,
-        }
-      }
-      Blue => {
-        HSBK {
-          hue: 0,
-          saturation: 0,
-          brightness: brightness,
-          kelvin: 0,
-        }
-      }
-      Green => {
-        HSBK {
-          hue: 120,
-          saturation: MAX_SATURATION,
-          brightness: brightness,
-          kelvin: DEFAULT_KELVIN,
-        }
-      }
-      Violet => {
-        HSBK {
-          hue: 0,
-          saturation: 0,
-          brightness: brightness,
-          kelvin: 0,
-        }
-      }
-      Yellow => {
-        HSBK {
-          hue: 0,
-          saturation: 0,
-          brightness: brightness,
-          kelvin: 0,
-        }
-      }
-      White => {
-        HSBK {
-          hue: 0,
-          saturation: 0,
-          brightness: brightness,
-          kelvin: 0,
-        }
-      }
+      Red => HSBK {
+        hue: 0,
+        saturation: MAX_SATURATION,
+        brightness: brightness,
+        kelvin: DEFAULT_KELVIN,
+      },
+      Blue => HSBK {
+        hue: 0,
+        saturation: 0,
+        brightness: brightness,
+        kelvin: 0,
+      },
+      Green => HSBK {
+        hue: 120,
+        saturation: MAX_SATURATION,
+        brightness: brightness,
+        kelvin: DEFAULT_KELVIN,
+      },
+      Violet => HSBK {
+        hue: 0,
+        saturation: 0,
+        brightness: brightness,
+        kelvin: 0,
+      },
+      Yellow => HSBK {
+        hue: 0,
+        saturation: 0,
+        brightness: brightness,
+        kelvin: 0,
+      },
+      White => HSBK {
+        hue: 0,
+        saturation: 0,
+        brightness: brightness,
+        kelvin: 0,
+      },
     }
   }
 }
-
 
 /// Labels from a LiFX blub are always 32 byte strings (not null terminated).
 /// Decodes a 32 byte string.
@@ -103,7 +87,6 @@ fn decode_32_byte_str<D: Decoder>(d: &mut D) -> Result<String, D::Error> {
   unsafe { Ok(String::from_utf8_unchecked(s)) }
 }
 
-
 /// Decodes a 16 byte array.
 ///
 fn decode_16_byte_arr<D: Decoder>(d: &mut D) -> Result<[u8; 16], D::Error> {
@@ -114,7 +97,6 @@ fn decode_16_byte_arr<D: Decoder>(d: &mut D) -> Result<[u8; 16], D::Error> {
   Ok(arr)
 }
 
-
 /// Decodes a 64 byte array.
 ///
 fn decode_64_byte_arr<D: Decoder>(d: &mut D) -> Result<[u8; 64], D::Error> {
@@ -124,7 +106,6 @@ fn decode_64_byte_arr<D: Decoder>(d: &mut D) -> Result<[u8; 64], D::Error> {
   }
   Ok(arr)
 }
-
 
 /// Service enumeration.
 ///
@@ -174,7 +155,6 @@ impl Encodable for Service {
   }
 }
 
-
 /// Power level for Device::SetPower and Device::GetPower.
 ///
 #[derive(Debug, Copy, Clone)]
@@ -217,11 +197,11 @@ impl Encodable for Power {
       Max => "Max",
     };
 
-    s.emit_enum("Power",
-                |s| s.emit_enum_variant(var, id as usize, 0, |s| s.emit_u16(id)))
+    s.emit_enum("Power", |s| {
+      s.emit_enum_variant(var, id as usize, 0, |s| s.emit_u16(id))
+    })
   }
 }
-
 
 /// HSBK (Hue, Saturation, Brightness, Kelvin)
 ///
@@ -245,7 +225,6 @@ impl HSBK {
     }
   }
 }
-
 
 /// Payload enumeration.
 ///
@@ -350,8 +329,12 @@ impl Payload {
         Ok(Payload::Device(Device::StateWifiFirmware(build, version)))
       }
       20 => Ok(Payload::Device(Device::GetPower)),
-      21 => Ok(Payload::Device(Device::SetPower(From::from(try!(d.read_u16()))))),
-      22 => Ok(Payload::Device(Device::StatePower(From::from(try!(d.read_u16()))))),
+      21 => Ok(Payload::Device(Device::SetPower(From::from(try!(
+        d.read_u16()
+      ))))),
+      22 => Ok(Payload::Device(Device::StatePower(From::from(try!(
+        d.read_u16()
+      ))))),
       23 => Ok(Payload::Device(Device::GetLabel)),
       25 => {
         let label = try!(decode_32_byte_str(d));
@@ -364,7 +347,9 @@ impl Payload {
         let product = try!(d.read_u32());
         let version = try!(d.read_u32());
 
-        Ok(Payload::Device(Device::StateVersion(vendor, product, version)))
+        Ok(Payload::Device(Device::StateVersion(
+          vendor, product, version,
+        )))
       }
       34 => Ok(Payload::Device(Device::GetInfo)),
       35 => {
@@ -381,7 +366,9 @@ impl Payload {
         let label = try!(decode_32_byte_str(d));
         let updated = try!(d.read_u64());
 
-        Ok(Payload::Device(Device::StateLocation(location, label, updated)))
+        Ok(Payload::Device(Device::StateLocation(
+          location, label, updated,
+        )))
       }
       51 => Ok(Payload::Device(Device::GetGroup)),
       53 => {
@@ -391,8 +378,12 @@ impl Payload {
 
         Ok(Payload::Device(Device::StateGroup(group, label, updated)))
       }
-      58 => Ok(Payload::Device(Device::EchoRequest(Array64(try!(decode_64_byte_arr(d)))))),
-      59 => Ok(Payload::Device(Device::EchoResponse(Array64(try!(decode_64_byte_arr(d)))))),
+      58 => Ok(Payload::Device(Device::EchoRequest(Array64(try!(
+        decode_64_byte_arr(d)
+      ))))),
+      59 => Ok(Payload::Device(Device::EchoResponse(Array64(try!(
+        decode_64_byte_arr(d)
+      ))))),
       101 => Ok(Payload::Light(Light::Get)),
       102 => {
         let _ = try!(d.read_u8());
@@ -417,16 +408,19 @@ impl Payload {
 
         Ok(Payload::Light(Light::SetPower(level, duration)))
       }
-      118 => Ok(Payload::Light(Light::StatePower(From::from(try!(d.read_u16()))))),
+      118 => Ok(Payload::Light(Light::StatePower(From::from(try!(
+        d.read_u16()
+      ))))),
       _ => Err(d.error("unrecognized message")),
     }
   }
 }
 
-
 pub struct Array64<T>(pub [T; 64]);
 
-impl<T> Encodable for Array64<T> where T: Encodable
+impl<T> Encodable for Array64<T>
+where
+  T: Encodable,
 {
   fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
     let &Array64(ref inner) = self;
@@ -438,7 +432,6 @@ impl<T> Encodable for Array64<T> where T: Encodable
     })
   }
 }
-
 
 /// Device message.
 ///
@@ -522,19 +515,9 @@ impl Device {
     use Device::*;
 
     match *self {
-      GetService |
-      GetHostInfo |
-      GetHostFirmware |
-      GetWifiInfo |
-      GetWifiFirmware |
-      GetPower |
-      SetPower(_) |
-      GetLabel |
-      GetVersion |
-      GetInfo |
-      GetLocation |
-      GetGroup |
-      EchoRequest(_) => true,
+      GetService | GetHostInfo | GetHostFirmware | GetWifiInfo | GetWifiFirmware
+      | GetPower | SetPower(_) | GetLabel | GetVersion | GetInfo | GetLocation
+      | GetGroup | EchoRequest(_) => true,
       _ => false,
     }
   }
@@ -544,18 +527,9 @@ impl Device {
     use Device::*;
 
     match *self {
-      GetService |
-      GetHostInfo |
-      GetHostFirmware |
-      GetWifiInfo |
-      GetWifiFirmware |
-      GetPower |
-      GetLabel |
-      GetVersion |
-      GetInfo |
-      Acknowledgement |
-      GetLocation |
-      GetGroup => 0,
+      GetService | GetHostInfo | GetHostFirmware | GetWifiInfo | GetWifiFirmware
+      | GetPower | GetLabel | GetVersion | GetInfo | Acknowledgement
+      | GetLocation | GetGroup => 0,
       SetPower(_) | StatePower(_) => 2,
       StateService(_, _) => 5,
       StateVersion(_, _, _) => 12,
@@ -620,7 +594,6 @@ impl Debug for Device {
   }
 }
 
-
 /// Light messages.
 ///
 #[derive(Debug)]
@@ -681,40 +654,37 @@ impl Encodable for Light {
   fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
     use Light::*;
 
-    s.emit_enum("Light", |s| {
-      match *self {
-        Get => s.emit_enum_variant("Get", 0, self.size() as usize, |s| s.emit_nil()),
-        SetColor(color, power) => {
-          s.emit_enum_variant("SetColor", 1, self.size() as usize, |s| {
-            try!(s.emit_enum_variant_arg(0, |s| s.emit_u8(0)));
-            try!(s.emit_enum_variant_arg(1, |s| color.encode(s)));
-            s.emit_enum_variant_arg(2, |s| s.emit_u32(power))
-          })
-        }
-        State(color, power, ref label) => {
-          s.emit_enum_variant("State", 2, self.size() as usize, |s| {
-            try!(s.emit_enum_variant_arg(0, |s| color.encode(s)));
-            try!(s.emit_enum_variant_arg(1, |s| s.emit_u16(0)));
-            try!(s.emit_enum_variant_arg(2, |s| s.emit_u16(power)));
-            try!(s.emit_enum_variant_arg(3, |s| label.encode(s)));
-            s.emit_enum_variant_arg(3, |s| s.emit_u64(0))
-          })
-        }
-        GetPower => {
-          s.emit_enum_variant("GetPower", 3, self.size() as usize, |s| s.emit_nil())
-        }
-        SetPower(level, duration) => {
-          s.emit_enum_variant("SetPower", 4, self.size() as usize, |s| {
-            try!(s.emit_enum_variant_arg(0, |s| level.encode(s)));
-            s.emit_enum_variant_arg(1, |s| s.emit_u32(duration))
-          })
-        }
-        StatePower(level) => {
-          s.emit_enum_variant("StatePower",
-                              5,
-                              self.size() as usize,
-                              |s| s.emit_enum_variant_arg(0, |s| level.encode(s)))
-        }
+    s.emit_enum("Light", |s| match *self {
+      Get => s.emit_enum_variant("Get", 0, self.size() as usize, |s| s.emit_nil()),
+      SetColor(color, power) => {
+        s.emit_enum_variant("SetColor", 1, self.size() as usize, |s| {
+          try!(s.emit_enum_variant_arg(0, |s| s.emit_u8(0)));
+          try!(s.emit_enum_variant_arg(1, |s| color.encode(s)));
+          s.emit_enum_variant_arg(2, |s| s.emit_u32(power))
+        })
+      }
+      State(color, power, ref label) => {
+        s.emit_enum_variant("State", 2, self.size() as usize, |s| {
+          try!(s.emit_enum_variant_arg(0, |s| color.encode(s)));
+          try!(s.emit_enum_variant_arg(1, |s| s.emit_u16(0)));
+          try!(s.emit_enum_variant_arg(2, |s| s.emit_u16(power)));
+          try!(s.emit_enum_variant_arg(3, |s| label.encode(s)));
+          s.emit_enum_variant_arg(3, |s| s.emit_u64(0))
+        })
+      }
+      GetPower => {
+        s.emit_enum_variant("GetPower", 3, self.size() as usize, |s| s.emit_nil())
+      }
+      SetPower(level, duration) => {
+        s.emit_enum_variant("SetPower", 4, self.size() as usize, |s| {
+          try!(s.emit_enum_variant_arg(0, |s| level.encode(s)));
+          s.emit_enum_variant_arg(1, |s| s.emit_u32(duration))
+        })
+      }
+      StatePower(level) => {
+        s.emit_enum_variant("StatePower", 5, self.size() as usize, |s| {
+          s.emit_enum_variant_arg(0, |s| level.encode(s))
+        })
       }
     })
   }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,9 +1,8 @@
-use std::mem;
 use std::io::Cursor;
+use std::mem;
 
-use byteorder::{LittleEndian, WriteBytesExt, ReadBytesExt};
-use rustc_serialize::{Encoder, Encodable, Decoder, Decodable};
-
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 /// encodes a series of bytes
 ///
@@ -19,7 +18,6 @@ pub fn decode<T: Decodable>(data: &[u8]) -> Result<T, String> {
   let mut decoder = ByteDecoder::new(data);
   T::decode(&mut decoder)
 }
-
 
 struct ByteEncoder {
   bytes: Vec<u8>,
@@ -51,17 +49,26 @@ impl Encoder for ByteEncoder {
 
   #[inline]
   fn emit_u64(&mut self, v: u64) -> Result<(), Self::Error> {
-    self.bytes.write_u64::<LittleEndian>(v).or(err!("failed to write u64"))
+    self
+      .bytes
+      .write_u64::<LittleEndian>(v)
+      .or(err!("failed to write u64"))
   }
 
   #[inline]
   fn emit_u32(&mut self, v: u32) -> Result<(), Self::Error> {
-    self.bytes.write_u32::<LittleEndian>(v).or(err!("failed to write u32"))
+    self
+      .bytes
+      .write_u32::<LittleEndian>(v)
+      .or(err!("failed to write u32"))
   }
 
   #[inline]
   fn emit_u16(&mut self, v: u16) -> Result<(), Self::Error> {
-    self.bytes.write_u16::<LittleEndian>(v).or(err!("failed to write u16"))
+    self
+      .bytes
+      .write_u16::<LittleEndian>(v)
+      .or(err!("failed to write u16"))
   }
 
   #[inline]
@@ -80,17 +87,26 @@ impl Encoder for ByteEncoder {
 
   #[inline]
   fn emit_i64(&mut self, v: i64) -> Result<(), Self::Error> {
-    self.bytes.write_i64::<LittleEndian>(v).or(err!("failed to write i64"))
+    self
+      .bytes
+      .write_i64::<LittleEndian>(v)
+      .or(err!("failed to write i64"))
   }
 
   #[inline]
   fn emit_i32(&mut self, v: i32) -> Result<(), Self::Error> {
-    self.bytes.write_i32::<LittleEndian>(v).or(err!("failed to write i32"))
+    self
+      .bytes
+      .write_i32::<LittleEndian>(v)
+      .or(err!("failed to write i32"))
   }
 
   #[inline]
   fn emit_i16(&mut self, v: i16) -> Result<(), Self::Error> {
-    self.bytes.write_i16::<LittleEndian>(v).or(err!("failed to write i16"))
+    self
+      .bytes
+      .write_i16::<LittleEndian>(v)
+      .or(err!("failed to write i16"))
   }
 
   #[inline]
@@ -105,12 +121,18 @@ impl Encoder for ByteEncoder {
 
   #[inline]
   fn emit_f64(&mut self, v: f64) -> Result<(), Self::Error> {
-    self.bytes.write_f64::<LittleEndian>(v).or(err!("failed to write f64"))
+    self
+      .bytes
+      .write_f64::<LittleEndian>(v)
+      .or(err!("failed to write f64"))
   }
 
   #[inline]
   fn emit_f32(&mut self, v: f32) -> Result<(), Self::Error> {
-    self.bytes.write_f32::<LittleEndian>(v).or(err!("failed to write f32"))
+    self
+      .bytes
+      .write_f32::<LittleEndian>(v)
+      .or(err!("failed to write f32"))
   }
 
   #[inline]
@@ -138,106 +160,123 @@ impl Encoder for ByteEncoder {
 
   #[inline]
   fn emit_enum<F>(&mut self, _: &str, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   #[inline]
-  fn emit_enum_variant<F>(&mut self,
-                          _: &str,
-                          _: usize,
-                          _: usize,
-                          f: F)
-                          -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  fn emit_enum_variant<F>(
+    &mut self,
+    _: &str,
+    _: usize,
+    _: usize,
+    f: F,
+  ) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn emit_enum_variant_arg<F>(&mut self, _: usize, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   #[inline]
-  fn emit_enum_struct_variant<F>(&mut self,
-                                 _: &str,
-                                 _: usize,
-                                 _: usize,
-                                 f: F)
-                                 -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  fn emit_enum_struct_variant<F>(
+    &mut self,
+    _: &str,
+    _: usize,
+    _: usize,
+    f: F,
+  ) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   #[inline]
-  fn emit_enum_struct_variant_field<F>(&mut self,
-                                       _: &str,
-                                       _: usize,
-                                       f: F)
-                                       -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  fn emit_enum_struct_variant_field<F>(
+    &mut self,
+    _: &str,
+    _: usize,
+    f: F,
+  ) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn emit_struct<F>(&mut self, _: &str, _: usize, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   #[inline]
-  fn emit_struct_field<F>(&mut self,
-                          _: &str,
-                          _: usize,
-                          f: F)
-                          -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  fn emit_struct_field<F>(
+    &mut self,
+    _: &str,
+    _: usize,
+    f: F,
+  ) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn emit_tuple<F>(&mut self, _: usize, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn emit_tuple_arg<F>(&mut self, _: usize, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   #[inline]
-  fn emit_tuple_struct<F>(&mut self,
-                          _: &str,
-                          _: usize,
-                          f: F)
-                          -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  fn emit_tuple_struct<F>(
+    &mut self,
+    _: &str,
+    _: usize,
+    f: F,
+  ) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn emit_tuple_struct_arg<F>(&mut self, _: usize, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn emit_option<F>(&mut self, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
@@ -247,44 +286,48 @@ impl Encoder for ByteEncoder {
   }
 
   fn emit_option_some<F>(&mut self, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     try!(self.emit_u8(1));
     f(self)
   }
 
   fn emit_seq<F>(&mut self, _: usize, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
-
     f(self)
   }
 
   fn emit_seq_elt<F>(&mut self, _: usize, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   fn emit_map<F>(&mut self, _: usize, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   fn emit_map_elt_key<F>(&mut self, _: usize, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 
   fn emit_map_elt_val<F>(&mut self, _: usize, f: F) -> Result<(), Self::Error>
-    where F: FnOnce(&mut Self) -> Result<(), Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<(), Self::Error>,
   {
     f(self)
   }
 }
-
 
 struct ByteDecoder<'a> {
   cursor: Cursor<&'a [u8]>,
@@ -293,7 +336,9 @@ struct ByteDecoder<'a> {
 impl<'a> ByteDecoder<'a> {
   #[inline(always)]
   fn new(bytes: &[u8]) -> ByteDecoder {
-    ByteDecoder { cursor: Cursor::new(bytes) }
+    ByteDecoder {
+      cursor: Cursor::new(bytes),
+    }
   }
 
   fn read_char_with_first_byte(&mut self, first: u8) -> Result<char, String> {
@@ -346,25 +391,35 @@ impl<'a> Decoder for ByteDecoder<'a> {
 
   #[inline]
   fn read_usize(&mut self) -> Result<usize, Self::Error> {
-    self.cursor
-        .read_uint::<LittleEndian>(mem::size_of::<usize>())
-        .and_then(|v| Ok(v as usize))
-        .or(err!("read usize failed"))
+    self
+      .cursor
+      .read_uint::<LittleEndian>(mem::size_of::<usize>())
+      .and_then(|v| Ok(v as usize))
+      .or(err!("read usize failed"))
   }
 
   #[inline]
   fn read_u64(&mut self) -> Result<u64, Self::Error> {
-    self.cursor.read_u64::<LittleEndian>().or(err!("read u64 failed"))
+    self
+      .cursor
+      .read_u64::<LittleEndian>()
+      .or(err!("read u64 failed"))
   }
 
   #[inline]
   fn read_u32(&mut self) -> Result<u32, Self::Error> {
-    self.cursor.read_u32::<LittleEndian>().or(err!("read u32 failed"))
+    self
+      .cursor
+      .read_u32::<LittleEndian>()
+      .or(err!("read u32 failed"))
   }
 
   #[inline]
   fn read_u16(&mut self) -> Result<u16, Self::Error> {
-    self.cursor.read_u16::<LittleEndian>().or(err!("read u16 failed"))
+    self
+      .cursor
+      .read_u16::<LittleEndian>()
+      .or(err!("read u16 failed"))
   }
 
   #[inline]
@@ -374,25 +429,35 @@ impl<'a> Decoder for ByteDecoder<'a> {
 
   #[inline]
   fn read_isize(&mut self) -> Result<isize, Self::Error> {
-    self.cursor
-        .read_int::<LittleEndian>(mem::size_of::<isize>())
-        .and_then(|v| Ok(v as isize))
-        .or(err!("read isize failed"))
+    self
+      .cursor
+      .read_int::<LittleEndian>(mem::size_of::<isize>())
+      .and_then(|v| Ok(v as isize))
+      .or(err!("read isize failed"))
   }
 
   #[inline]
   fn read_i64(&mut self) -> Result<i64, Self::Error> {
-    self.cursor.read_i64::<LittleEndian>().or(err!("read i64 failed"))
+    self
+      .cursor
+      .read_i64::<LittleEndian>()
+      .or(err!("read i64 failed"))
   }
 
   #[inline]
   fn read_i32(&mut self) -> Result<i32, Self::Error> {
-    self.cursor.read_i32::<LittleEndian>().or(err!("read i32 failed"))
+    self
+      .cursor
+      .read_i32::<LittleEndian>()
+      .or(err!("read i32 failed"))
   }
 
   #[inline]
   fn read_i16(&mut self) -> Result<i16, Self::Error> {
-    self.cursor.read_i16::<LittleEndian>().or(err!("read i16 failed"))
+    self
+      .cursor
+      .read_i16::<LittleEndian>()
+      .or(err!("read i16 failed"))
   }
 
   #[inline]
@@ -402,17 +467,26 @@ impl<'a> Decoder for ByteDecoder<'a> {
 
   #[inline]
   fn read_bool(&mut self) -> Result<bool, Self::Error> {
-    self.read_u8().and_then(|b| Ok(b > 0)).or(err!("read bool failed"))
+    self
+      .read_u8()
+      .and_then(|b| Ok(b > 0))
+      .or(err!("read bool failed"))
   }
 
   #[inline]
   fn read_f64(&mut self) -> Result<f64, Self::Error> {
-    self.cursor.read_f64::<LittleEndian>().or(err!("read f64 failed"))
+    self
+      .cursor
+      .read_f64::<LittleEndian>()
+      .or(err!("read f64 failed"))
   }
 
   #[inline]
   fn read_f32(&mut self) -> Result<f32, Self::Error> {
-    self.cursor.read_f32::<LittleEndian>().or(err!("read f32 failed"))
+    self
+      .cursor
+      .read_f32::<LittleEndian>()
+      .or(err!("read f32 failed"))
   }
 
   #[inline]
@@ -440,137 +514,159 @@ impl<'a> Decoder for ByteDecoder<'a> {
 
   #[inline]
   fn read_enum<T, F>(&mut self, _: &str, f: F) -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }
 
   #[inline]
-  fn read_enum_variant<T, F>(&mut self,
-                             _: &[&str],
-                             mut f: F)
-                             -> Result<T, Self::Error>
-    where F: FnMut(&mut Self, usize) -> Result<T, Self::Error>
+  fn read_enum_variant<T, F>(
+    &mut self,
+    _: &[&str],
+    mut f: F,
+  ) -> Result<T, Self::Error>
+  where
+    F: FnMut(&mut Self, usize) -> Result<T, Self::Error>,
   {
     f(self, 0)
   }
 
   #[inline]
   fn read_enum_variant_arg<T, F>(&mut self, _: usize, f: F) -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }
 
   #[inline]
-  fn read_enum_struct_variant<T, F>(&mut self,
-                                    _: &[&str],
-                                    mut f: F)
-                                    -> Result<T, Self::Error>
-    where F: FnMut(&mut Self, usize) -> Result<T, Self::Error>
+  fn read_enum_struct_variant<T, F>(
+    &mut self,
+    _: &[&str],
+    mut f: F,
+  ) -> Result<T, Self::Error>
+  where
+    F: FnMut(&mut Self, usize) -> Result<T, Self::Error>,
   {
     f(self, 0)
   }
 
   #[inline]
-  fn read_enum_struct_variant_field<T, F>(&mut self,
-                                          _: &str,
-                                          _: usize,
-                                          f: F)
-                                          -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  fn read_enum_struct_variant_field<T, F>(
+    &mut self,
+    _: &str,
+    _: usize,
+    f: F,
+  ) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn read_struct<T, F>(&mut self, _: &str, _: usize, f: F) -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }
 
   #[inline]
-  fn read_struct_field<T, F>(&mut self,
-                             _: &str,
-                             _: usize,
-                             f: F)
-                             -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  fn read_struct_field<T, F>(
+    &mut self,
+    _: &str,
+    _: usize,
+    f: F,
+  ) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn read_tuple<T, F>(&mut self, _: usize, f: F) -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn read_tuple_arg<T, F>(&mut self, _: usize, f: F) -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }
 
   #[inline]
-  fn read_tuple_struct<T, F>(&mut self,
-                             _: &str,
-                             _: usize,
-                             f: F)
-                             -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  fn read_tuple_struct<T, F>(
+    &mut self,
+    _: &str,
+    _: usize,
+    f: F,
+  ) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn read_tuple_struct_arg<T, F>(&mut self, _: usize, f: F) -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn read_option<T, F>(&mut self, mut f: F) -> Result<T, Self::Error>
-    where F: FnMut(&mut Self, bool) -> Result<T, Self::Error>
+  where
+    F: FnMut(&mut Self, bool) -> Result<T, Self::Error>,
   {
     f(self, false)
   }
 
   #[inline]
   fn read_seq<T, F>(&mut self, f: F) -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self, usize) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self, usize) -> Result<T, Self::Error>,
   {
     f(self, 0)
   }
 
   #[inline]
   fn read_seq_elt<T, F>(&mut self, _: usize, f: F) -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn read_map<T, F>(&mut self, f: F) -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self, usize) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self, usize) -> Result<T, Self::Error>,
   {
     f(self, 0)
   }
 
   #[inline]
   fn read_map_elt_key<T, F>(&mut self, _: usize, f: F) -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }
 
   #[inline]
   fn read_map_elt_val<T, F>(&mut self, _: usize, f: F) -> Result<T, Self::Error>
-    where F: FnOnce(&mut Self) -> Result<T, Self::Error>
+  where
+    F: FnOnce(&mut Self) -> Result<T, Self::Error>,
   {
     f(self)
   }


### PR DESCRIPTION
Used `cargo fmt` to provide consistent source code formatting.